### PR TITLE
fix: avoid KeyError while accessing 'app_id' on build schema

### DIFF
--- a/flamingo/models/build.py
+++ b/flamingo/models/build.py
@@ -43,7 +43,7 @@ class Build(EmbeddedDocument):
 
     def to_dict(self) -> Dict:
         data = super().to_dict()
-        data.pop("app_id")
+        data.pop("app_id", None)
 
         data.pop("build_pack_name")
         data["build_pack"] = self.build_pack.to_dict()


### PR DESCRIPTION
This field is not defined in most of app.