### PR TITLE
Adjusts after changing to pydantic

### DIFF
--- a/flamingo/models/app.py
+++ b/flamingo/models/app.py
@@ -65,6 +65,8 @@ class App(Document):
 
         data.pop("environment_name")
         data["environment"] = self.environment.to_dict()
+        data["build"] = self.build.to_dict()
+
         if self.service_account:
             data["service_account"].pop("key")
             if self.service_account.json_key:

--- a/flamingo/models/app.py
+++ b/flamingo/models/app.py
@@ -221,7 +221,7 @@ class App(Document):
 
         if trigger_id != build.trigger_id:
             build.trigger_id = trigger_id
-            App.documents.update(pk=self.pk, build=build)
+            App.documents.update(pk=self.pk, build=build.dict(exclude={"build_pack"}))
 
             # Since we need the Trigger ID inside the trigger yaml to be used as a CloudRun service label
             # The first time we create the trigger the yaml goes without the label, so we recreate it

--- a/flamingo/models/build.py
+++ b/flamingo/models/build.py
@@ -43,8 +43,6 @@ class Build(EmbeddedDocument):
 
     def to_dict(self) -> Dict:
         data = super().to_dict()
-        data.pop("app_id", None)
-
         data.pop("build_pack_name")
         data["build_pack"] = self.build_pack.to_dict()
 


### PR DESCRIPTION
The following tests were done about App operations:  update, detail, list and apply. All of them have been successfully stored data trusting pydantic model.

A few descriptions of how those methods work:
On update, Sanic just parses the received body and then updates the entity using the payload, the output is `entity.to_dict()`. 
To list/details/update (response) have a similiar process, after fetching the object runs `.to_dict()`
That's why we have to add `self.build.to_dict()` on `App.to_dict()`, to ensure our custom `to_dict` method will be called.

On apply, we were updating all models attributes (including cached_properties), that's why we are ignoring it