### PR TITLE
fix: cast sanic port to integer

### DIFF
--- a/flamingo/main.py
+++ b/flamingo/main.py
@@ -19,4 +19,4 @@ app.blueprint(swagger_blueprint)
 app.blueprint(views.api)
 
 if __name__ == "__main__":
-    app.run(host=os.environ.get("HOST", "0.0.0.0"), port=os.environ.get("PORT", 8000))
+    app.run(host=os.environ.get("HOST", "0.0.0.0"), port=int(os.environ.get("PORT", 8000)))


### PR DESCRIPTION
The older version of sanic had support to seting the PORT as a numeric string, but the newer versions require an integer.